### PR TITLE
Add lint workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: Lint
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  flake8:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install black flake8 -r requirements.txt
+
+      - name: Run Black check
+        run: black --check status_api.py
+
+      - name: Run Flake8
+        run: flake8 status_api.py

--- a/status_api.py
+++ b/status_api.py
@@ -16,18 +16,20 @@ app.add_middleware(
 )
 
 SERVERS = {
-    "minecraft":  {"host": "mc.rcfg.xyz",    "port": 25565, "type": "minecraft"},
-    "craftoria":  {"host": "46.4.224.70",     "port": 25580, "type": "minecraft"},
-    "cs2":        {"host": "135.181.19.52",   "port": 27020, "type": "source"},
-    "arma":       {"host": "135.181.19.52",   "port": 2001,  "type": "tcp"},
+    "minecraft": {"host": "mc.rcfg.xyz", "port": 25565, "type": "minecraft"},
+    "craftoria": {"host": "46.4.224.70", "port": 25580, "type": "minecraft"},
+    "cs2": {"host": "135.181.19.52", "port": 27020, "type": "source"},
+    "arma": {"host": "135.181.19.52", "port": 2001, "type": "tcp"},
 }
 _cache = {}
 TTL = 30  # seconds
 
+
 class Status(BaseModel):
-    online:      bool
-    players:     int = 0
+    online: bool
+    players: int = 0
     max_players: int = 0
+
 
 def get_cached(key: str):
     ent = _cache.get(key)
@@ -35,27 +37,37 @@ def get_cached(key: str):
         return ent["val"]
     return None
 
+
 def set_cache(key: str, val: Status):
     _cache[key] = {"val": val, "ts": time()}
+
 
 async def ping_minecraft(host: str, port: int) -> Status:
     try:
         srv = JavaServer(host, port)
         stat = await asyncio.get_event_loop().run_in_executor(None, srv.status)
-        return Status(online=True,
-                      players=stat.players.online,
-                      max_players=stat.players.max)
-    except:
+        return Status(
+            online=True,
+            players=stat.players.online,
+            max_players=stat.players.max,
+        )
+    except Exception:
         return Status(online=False)
+
 
 async def ping_source(host: str, port: int) -> Status:
     try:
-        info = await asyncio.get_event_loop().run_in_executor(None, lambda: a2s.info((host, port)))
-        return Status(online=True,
-                      players=info.player_count,
-                      max_players=info.max_players)
-    except:
+        info = await asyncio.get_event_loop().run_in_executor(
+            None, lambda: a2s.info((host, port))
+        )
+        return Status(
+            online=True,
+            players=info.player_count,
+            max_players=info.max_players,
+        )
+    except Exception:
         return Status(online=False)
+
 
 async def ping_tcp(host: str, port: int) -> Status:
     try:
@@ -63,8 +75,9 @@ async def ping_tcp(host: str, port: int) -> Status:
         writer.close()
         await writer.wait_closed()
         return Status(online=True)
-    except:
+    except Exception:
         return Status(online=False)
+
 
 @app.get("/api/status/{srv_name}", response_model=Status)
 async def get_status(srv_name: str):


### PR DESCRIPTION
## Summary
- add lint workflow that checks code with Black and Flake8
- clean up `status_api.py` to satisfy linting

## Testing
- `black --check status_api.py`
- `flake8 status_api.py`


------
https://chatgpt.com/codex/tasks/task_e_6877f34c214c832ebb64e58980dfe524