### PR TITLE
Add auto-deploy workflow

### DIFF
--- a/.github/workflows/deploy-server.yml
+++ b/.github/workflows/deploy-server.yml
@@ -1,0 +1,35 @@
+name: Deploy to Web Server
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Sync files to web server
+        uses: appleboy/scp-action@v0.1.5
+        with:
+          host: ${{ secrets.SERVER_HOST }}
+          username: ${{ secrets.SERVER_USER }}
+          key: ${{ secrets.SERVER_SSH_KEY }}
+          port: ${{ secrets.SERVER_PORT }}
+          source: '.'
+          target: '/var/www/rcfg_site'
+          strip_components: 0
+
+      - name: Restart services
+        uses: appleboy/ssh-action@v1.0.0
+        with:
+          host: ${{ secrets.SERVER_HOST }}
+          username: ${{ secrets.SERVER_USER }}
+          key: ${{ secrets.SERVER_SSH_KEY }}
+          port: ${{ secrets.SERVER_PORT }}
+          script: |
+            sudo systemctl restart status_api.service
+            sudo systemctl reload nginx

--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# RCFG Website
+
+This repository contains the source for the RCFG website and the status API service.
+
+## Automatic Deployment
+
+Two GitHub Actions workflows keep the site up to date:
+
+- **Deploy to GitHub Pages** – publishes the repository contents to GitHub Pages whenever changes are pushed to the `main` branch.
+- **Deploy to Web Server** – synchronises the repository with the production server via SSH on every push to `main`.
+
+To enable server deployment, define the following secrets in the repository settings:
+
+- `SERVER_HOST` – hostname or IP of the server.
+- `SERVER_PORT` – SSH port (default `22`).
+- `SERVER_USER` – SSH user used for deployment.
+- `SERVER_SSH_KEY` – private key for the SSH user.
+
+The workflow copies the repository to `/var/www/rcfg_site` and then restarts the `status_api` service and reloads Nginx.


### PR DESCRIPTION
## Summary
- deploy to the production web server via SSH on each push to `main`
- document the secrets required for deployment

## Testing
- `python3 -m pip install fastapi uvicorn mcstatus pydantic`
- `python3 -m pip install valve-source-query` *(fails: no matching distribution)*

------
https://chatgpt.com/codex/tasks/task_e_6877f471f670832e9c236a70e9ec392a